### PR TITLE
MacOS: fix: enable IP forwarding on host

### DIFF
--- a/user_scripts/halt/90_nat.sh
+++ b/user_scripts/halt/90_nat.sh
@@ -8,6 +8,7 @@ echo "==> Disabling IP Masquerading"
 if [[ "$uname_str" == "Linux" ]]; then
 	sudo iptables -t nat -D POSTROUTING -s 192.168.33.0/24 -j MASQUERADE
 elif [[ "$uname_str" == "Darwin" ]]; then
+	sudo sysctl -w net.inet.ip.forwarding=0
 	sudo pfctl -df /etc/pf.conf > /dev/null 2>&1;
 else
 	echo "FAILED! Host OS unknown"

--- a/user_scripts/up/10_nat.sh
+++ b/user_scripts/up/10_nat.sh
@@ -8,6 +8,7 @@ echo "==> Enabling IP Masquerading"
 if [[ "$uname_str" == "Linux" ]]; then
 	sudo iptables -t nat -A POSTROUTING -s 192.168.33.0/24 -j MASQUERADE
 elif [[ "$uname_str" == "Darwin" ]]; then
+	sudo sysctl -w net.inet.ip.forwarding=1
 	echo "nat on en0 from 192.168.33.0/24 to any -> en0" | sudo pfctl -ef - >/dev/null 2>&1; 
 else
 	echo "FAILED! Host OS unknown"


### PR DESCRIPTION
we need to enable IP forwarding to do NAT on new MacOS
credit: @ginoledesma found this first