### PR TITLE
Use built-in Vagrant triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Requirements
 You need a recent vagrant installed and virtualbox. Get it at http://www.vagrantup.com/downloads.html
 and https://www.virtualbox.org/wiki/Downloads
 
-The plugin  vagrant-trigger is also required (see below for installing it).
-
 You also need to have root access via sudo so the script can add NAT rules.
 Currently Linux and Mac OS X hosts are supported.
 
@@ -22,8 +20,6 @@ Get it and use it:
 
     git clone https://github.com/multipath-tcp/mptcp-vagrant.git
     cd mptcp-vagrant
-    # only the first time:
-    vagrant plugin install vagrant-triggers
     vagrant up
 
 This will:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -150,10 +150,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
    #######################################################################
 }   
 
-  config.trigger.after :up do 
-    run "./scripts/post_up.sh"
+  config.trigger.after :up do |trigger|
+    trigger.run = {path: "scripts/post_up.sh"}
   end
-  config.trigger.after :halt do 
-    run "./scripts/post_halt.sh"
+  config.trigger.after :halt do |trigger|
+    trigger.run = {path: "scripts/post_halt.sh"}
   end
 end


### PR DESCRIPTION
Latest version of Vagrant (2.1.1) has a built-in trigger functionality.

This PR updates the Vagrantfile to use it instead of the vagrant-trigger plugin.